### PR TITLE
Split transactions when regenerating previously removed user

### DIFF
--- a/state/user.go
+++ b/state/user.go
@@ -169,6 +169,7 @@ func (st *State) updateExistingUser(u *User, displayName, password, creator stri
 			}},
 		)
 	}
+
 	// remove previous controller permissions
 	removeControllerOps := removeControllerUserOps(st.ControllerUUID(), u.UserTag())
 
@@ -190,7 +191,6 @@ func (st *State) updateExistingUser(u *User, displayName, password, creator stri
 		Assert: txn.DocExists,
 		Update: updateUser,
 	}}
-	// updateUserOps = append(updateUserOps, removeControllerOps...)
 	updateUserOps = append(updateUserOps, createControllerOps...)
 
 	if err := u.st.db().RunTransaction(updateUserOps); err != nil {

--- a/state/user.go
+++ b/state/user.go
@@ -172,7 +172,11 @@ func (st *State) updateExistingUser(u *User, displayName, password, creator stri
 	// remove previous controller permissions
 	removeControllerOps := removeControllerUserOps(st.ControllerUUID(), u.UserTag())
 
-	// create default new ones
+	if err := u.st.db().RunTransaction(removeControllerOps); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// // create default new ones
 	createControllerOps := createControllerUserOps(st.ControllerUUID(),
 		u.UserTag(),
 		names.NewUserTag(creator),
@@ -186,7 +190,7 @@ func (st *State) updateExistingUser(u *User, displayName, password, creator stri
 		Assert: txn.DocExists,
 		Update: updateUser,
 	}}
-	updateUserOps = append(updateUserOps, removeControllerOps...)
+	// updateUserOps = append(updateUserOps, removeControllerOps...)
 	updateUserOps = append(updateUserOps, createControllerOps...)
 
 	if err := u.st.db().RunTransaction(updateUserOps); err != nil {


### PR DESCRIPTION
When recreating a removed user, one of the `asserts` from existing transactions fail. This was not observed in 2.9. I have split the Transaction into two steps.
